### PR TITLE
More efficient subscriptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
         project: './tsconfig.json',
     },
     rules: {
+        'no-await-in-loop': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-redundant-type-constituents': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The backend API for Nexus.
 -   Cloudflare for CDN
 -   Upstash for Redis Cache Around DB and Storage Requests
 -   I am using forwardemail.net to forward emails to dbpiper@marslyceum.com to my gmail
+-   Doppler for secrets management
 
 ## DB
 

--- a/buckets/cors.json
+++ b/buckets/cors.json
@@ -2,7 +2,8 @@
     {
         "origin": [
             "https://dev.my-nexus.net",
-            "http://localhost:3000"
+            "http://localhost:3000",
+            "http://localhost:8081"
         ],
         "method": [
             "GET",

--- a/packages/direct-messaging-api-client/src/clients/DirectMessagingApiClient.ts
+++ b/packages/direct-messaging-api-client/src/clients/DirectMessagingApiClient.ts
@@ -16,7 +16,7 @@ import {
     UpdateMessageResponse,
 } from '../responses';
 
-const useLocalApi = true;
+const useLocalApi = false;
 
 export class DirectMessagingApiClient {
     private baseURL =

--- a/packages/direct-messaging-api-client/src/clients/DirectMessagingApiClient.ts
+++ b/packages/direct-messaging-api-client/src/clients/DirectMessagingApiClient.ts
@@ -16,7 +16,7 @@ import {
     UpdateMessageResponse,
 } from '../responses';
 
-const useLocalApi = false;
+const useLocalApi = true;
 
 export class DirectMessagingApiClient {
     private baseURL =

--- a/packages/friends-api-client/src/clients/FriendsApiClient.ts
+++ b/packages/friends-api-client/src/clients/FriendsApiClient.ts
@@ -17,8 +17,6 @@ export class FriendsApiClient {
             ? 'https://friends-api-197277044151.us-west1.run.app'
             : 'http://localhost:4003';
 
-    // private baseURL = 'http://localhost:4003';
-
     // eslint-disable-next-line class-methods-use-this
     private async query<T>(request: Promise<AxiosResponse<T>>): Promise<T> {
         try {

--- a/packages/group-api-client/src/clients/GroupApiClient.ts
+++ b/packages/group-api-client/src/clients/GroupApiClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 
-import { buildMultipartFormData } from 'common-utils';
+import { buildMultipartFormData, isRunningInCloudRun } from 'common-utils';
 
 import {
     CreateGroupPayload,
@@ -20,10 +20,13 @@ import {
     CreatePostCommentResponse,
 } from '../responses';
 
-export class GroupApiClient {
-    private baseURL = 'https://group-api-197277044151.us-west1.run.app';
+const useLocalApi = false;
 
-    // private baseURL = 'http://localhost:4002';
+export class GroupApiClient {
+    private baseURL =
+        isRunningInCloudRun() || !useLocalApi
+            ? 'https://group-api-197277044151.us-west1.run.app'
+            : 'http://localhost:4002';
 
     // eslint-disable-next-line class-methods-use-this
     private async query<T>(request: Promise<AxiosResponse<T>>): Promise<T> {

--- a/packages/user-api-client/src/models/User.ts
+++ b/packages/user-api-client/src/models/User.ts
@@ -13,4 +13,6 @@ export type User = {
         | 'offline_dnd'
         | 'online_dnd';
     token?: string;
+    accessToken?: string;
+    refreshToken?: string;
 };

--- a/packages/user-api-client/src/models/User.ts
+++ b/packages/user-api-client/src/models/User.ts
@@ -12,7 +12,4 @@ export type User = {
         | 'invisible'
         | 'offline_dnd'
         | 'online_dnd';
-    token?: string;
-    accessToken?: string;
-    refreshToken?: string;
 };

--- a/packages/user-api-client/src/responses/index.ts
+++ b/packages/user-api-client/src/responses/index.ts
@@ -1,8 +1,18 @@
 import { User } from '../models';
 
-export type LoginUserResponse = User;
+export type LoginUserResponse = User & {
+    token?: string;
+    accessToken?: string;
+    refreshToken?: string;
+    refreshTokenExpiresAt?: string;
+};
 
-export type CreateUserResponse = User;
+export type CreateUserResponse = User & {
+    token?: string;
+    accessToken?: string;
+    refreshToken?: string;
+    refreshTokenExpiresAt?: string;
+};
 
 export type GetUserResponse = User;
 

--- a/packages/user-api-client/src/schemas/index.ts
+++ b/packages/user-api-client/src/schemas/index.ts
@@ -56,6 +56,13 @@ export const updateUserPayloadSchema: ObjectSchema<UpdateUserPayload> =
         lastName: Joi.string().optional(),
         phoneNumber: Joi.string().optional(),
         status: Joi.string()
-            .valid('online', 'offline', 'idle', 'invisible', 'dnd')
+            .valid(
+                'online',
+                'offline',
+                'idle',
+                'invisible',
+                'offline_dnd',
+                'online_dnd'
+            )
             .optional(),
     });

--- a/services/direct-messaging-api/src/handlers/deleteMessage.ts
+++ b/services/direct-messaging-api/src/handlers/deleteMessage.ts
@@ -3,7 +3,10 @@ import {
     MessageEntity,
     DeleteMessageParams,
 } from 'direct-messaging-api-client';
-import { TypeOrmDataSourceSingleton } from 'third-party-clients';
+import {
+    GoogleCloudStorageSingleton,
+    TypeOrmDataSourceSingleton,
+} from 'third-party-clients';
 
 export const deleteMessage = async (
     req: Request<DeleteMessageParams, unknown, unknown>,
@@ -12,6 +15,20 @@ export const deleteMessage = async (
     try {
         const { messageId } = req.params;
         const dataSource = await TypeOrmDataSourceSingleton.getInstance();
+        const googleCloudStorage = GoogleCloudStorageSingleton.getInstance();
+
+        const message = await dataSource.manager.findOne(MessageEntity, {
+            where: { id: messageId },
+        });
+
+        if (message && message.attachmentFilePaths) {
+            for (const attachmentFilePath of message.attachmentFilePaths) {
+                await googleCloudStorage
+                    .bucket('dm-attachments')
+                    .file(attachmentFilePath)
+                    .delete();
+            }
+        }
 
         await dataSource.manager.delete(MessageEntity, { id: messageId });
 

--- a/services/direct-messaging-api/src/handlers/sendMessage.ts
+++ b/services/direct-messaging-api/src/handlers/sendMessage.ts
@@ -100,11 +100,6 @@ export const sendMessage = async (
                 const topicName = `u-${userId}`;
                 const topic = pubsub.topic(topicName);
 
-                const [exists] = await topic.exists();
-                if (!exists) {
-                    await pubsub.createTopic(topicName);
-                }
-
                 await topic.publishMessage({ data: dataBuffer });
             }
         }

--- a/services/friends-api/src/handlers/getFriends.ts
+++ b/services/friends-api/src/handlers/getFriends.ts
@@ -19,7 +19,7 @@ export const getFriends = async (
         // eslint-disable-next-line unicorn/no-array-callback-reference
         const friends = await dataSource.manager.find(FriendEntity, {
             where: { user: { id: userId } },
-            relations: ['friend', 'requestedBy'],
+            relations: ['friend', 'requestedBy', 'user'],
         });
 
         if (!friends) {

--- a/services/group-api/src/handlers/createGroupChannelMessage.ts
+++ b/services/group-api/src/handlers/createGroupChannelMessage.ts
@@ -152,11 +152,6 @@ export const createGroupChannelMessage = async (
                 const topicName = `u-${member.userId}`;
                 const topic = pubsub.topic(topicName);
 
-                const [exists] = await topic.exists();
-                if (!exists) {
-                    await pubsub.createTopic(topicName);
-                }
-
                 await topic.publishMessage({ data: dataBuffer });
             }
         }

--- a/services/nexus-web-service/package.json
+++ b/services/nexus-web-service/package.json
@@ -17,6 +17,7 @@
         "clean-pnpm": "python clean_pnpm.py"
     },
     "dependencies": {
+        "cookie": "^1.0.2",
         "@graphql-tools/merge": "^9.0.24",
         "jwt-decode": "^4.0.0",
         "auth0": "^4.20.0",

--- a/services/nexus-web-service/pnpm-lock.yaml
+++ b/services/nexus-web-service/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       common-middleware:
         specifier: workspace:*
         version: link:../../packages/common-middleware
+      cookie:
+        specifier: ^1.0.2
+        version: 1.0.2
       cookie-parser:
         specifier: ~1.4.4
         version: 1.4.6
@@ -229,10 +232,10 @@ importers:
         version: 0.2.2
       serverless-google-cloudfunctions:
         specifier: ^4.6.0
-        version: 4.6.0(serverless@3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9))
+        version: 4.6.0(serverless@3.39.0(debug@2.6.9))
       serverless-plugin-typescript:
         specifier: ^2.1.5
-        version: 2.1.5(serverless@3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9))(typescript@5.4.5)
+        version: 2.1.5(serverless@3.39.0(debug@2.6.9))(typescript@5.4.5)
       third-party-clients:
         specifier: workspace:*
         version: link:../../packages/third-party-clients
@@ -2625,6 +2628,10 @@ packages:
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -6201,10 +6208,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6249,10 +6256,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6297,10 +6304,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6343,10 +6350,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6389,10 +6396,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6436,10 +6443,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6488,10 +6495,10 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.598.0
       '@aws-sdk/middleware-expect-continue': 3.598.0
       '@aws-sdk/middleware-flexible-checksums': 3.598.0
@@ -6546,13 +6553,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.600.0':
+  '@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6589,6 +6596,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.598.0':
@@ -6634,13 +6642,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)':
+  '@aws-sdk/client-sts@3.600.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6677,7 +6685,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.598.0':
@@ -6709,13 +6716,13 @@ snapshots:
       '@smithy/util-stream': 3.0.4
       tslib: 2.6.3
 
-  '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
       '@aws-sdk/credential-provider-process': 3.598.0
-      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))
       '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/credential-provider-imds': 3.1.2
@@ -6727,13 +6734,13 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
-      '@aws-sdk/credential-provider-ini': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-ini': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/credential-provider-process': 3.598.0
-      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))
       '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/credential-provider-imds': 3.1.2
@@ -6754,10 +6761,10 @@ snapshots:
       '@smithy/types': 3.2.0
       tslib: 2.6.3
 
-  '@aws-sdk/credential-provider-sso@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)':
+  '@aws-sdk/credential-provider-sso@3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))':
     dependencies:
       '@aws-sdk/client-sso': 3.598.0
-      '@aws-sdk/token-providers': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/token-providers': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/shared-ini-file-loader': 3.1.2
@@ -6769,7 +6776,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.598.0(@aws-sdk/client-sts@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/types': 3.2.0
@@ -6890,9 +6897,9 @@ snapshots:
       '@smithy/types': 3.2.0
       tslib: 2.6.3
 
-  '@aws-sdk/token-providers@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)':
+  '@aws-sdk/token-providers@3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.600.0
+      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/shared-ini-file-loader': 3.1.2
@@ -8234,10 +8241,10 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@serverless/dashboard-plugin@7.2.3(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9)(supports-color@8.1.1)':
+  '@serverless/dashboard-plugin@7.2.3(debug@2.6.9)(supports-color@8.1.1)':
     dependencies:
       '@aws-sdk/client-cloudformation': 3.600.0
-      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/client-sts': 3.600.0
       '@serverless/event-mocks': 1.1.1
       '@serverless/platform-client': 4.5.1(debug@2.6.9)(supports-color@8.1.1)
       '@serverless/utils': 6.15.0
@@ -8260,7 +8267,6 @@ snapshots:
       uuid: 8.3.2
       yamljs: 0.3.0
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
       - bufferutil
       - debug
@@ -9836,6 +9842,8 @@ snapshots:
   cookie@0.5.0: {}
 
   cookie@0.6.0: {}
+
+  cookie@1.0.2: {}
 
   cookiejar@2.1.4: {}
 
@@ -12900,7 +12908,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serverless-google-cloudfunctions@4.6.0(serverless@3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9)):
+  serverless-google-cloudfunctions@4.6.0(serverless@3.39.0(debug@2.6.9)):
     dependencies:
       async: 2.6.4
       bluebird: 3.7.2
@@ -12910,20 +12918,20 @@ snapshots:
       get-stdin: 8.0.0
       googleapis: 50.0.0
       lodash: 4.17.21
-      serverless: 3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9)
+      serverless: 3.39.0(debug@2.6.9)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  serverless-plugin-typescript@2.1.5(serverless@3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9))(typescript@5.4.5):
+  serverless-plugin-typescript@2.1.5(serverless@3.39.0(debug@2.6.9))(typescript@5.4.5):
     dependencies:
       fs-extra: 7.0.1
       globby: 10.0.2
       lodash: 4.17.21
-      serverless: 3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9)
+      serverless: 3.39.0(debug@2.6.9)
       typescript: 5.4.5
 
-  serverless@3.39.0(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9):
+  serverless@3.39.0(debug@2.6.9):
     dependencies:
       '@aws-sdk/client-api-gateway': 3.600.0
       '@aws-sdk/client-cognito-identity-provider': 3.600.0
@@ -12931,7 +12939,7 @@ snapshots:
       '@aws-sdk/client-iam': 3.600.0
       '@aws-sdk/client-lambda': 3.600.0
       '@aws-sdk/client-s3': 3.600.0
-      '@serverless/dashboard-plugin': 7.2.3(@aws-sdk/client-sso-oidc@3.600.0)(debug@2.6.9)(supports-color@8.1.1)
+      '@serverless/dashboard-plugin': 7.2.3(debug@2.6.9)(supports-color@8.1.1)
       '@serverless/platform-client': 4.5.1(debug@2.6.9)(supports-color@8.1.1)
       '@serverless/utils': 6.15.0
       abort-controller: 3.0.0
@@ -12988,7 +12996,6 @@ snapshots:
       ws: 7.5.10
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
       - bufferutil
       - debug

--- a/services/nexus-web-service/src/config/loadDotenv.ts
+++ b/services/nexus-web-service/src/config/loadDotenv.ts
@@ -43,5 +43,6 @@ export const {
     AUTH0_CLIENT_ID,
     AUTH0_AUDIENCE,
     AUTH0_CLIENT_SECRET,
-    JWT_SECRET,
+    ACCESS_JWT_SECRET,
+    REFRESH_TOKEN_SECRET,
 } = process.env;

--- a/services/nexus-web-service/src/middleware/auth.ts
+++ b/services/nexus-web-service/src/middleware/auth.ts
@@ -21,11 +21,25 @@ export function authGuard({ operationName, req }: AuthGuardOptions): void {
     if (operationName && OPEN_OPERATIONS.has(operationName)) return;
 
     const token = getAccessToken(req);
-    if (!token) throw new UnauthenticatedError('Not authenticated');
+    if (!token) {
+        throw new UnauthenticatedError('Not authenticated. No token provided');
+    }
 
     try {
         jwt.verify(token, ACCESS_JWT_SECRET as jwt.Secret);
-    } catch {
-        throw new UnauthenticatedError('Invalid or expired token');
+    } catch (error: unknown) {
+        if (error instanceof jwt.TokenExpiredError) {
+            throw new UnauthenticatedError(
+                `Token expired at ${error.expiredAt.toISOString()}`
+            );
+        }
+
+        if (error instanceof jwt.JsonWebTokenError) {
+            throw new UnauthenticatedError(`Invalid token: ${error.message}`);
+        }
+
+        throw new UnauthenticatedError(
+            'Authentication failed due to an unexpected error'
+        );
     }
 }

--- a/services/nexus-web-service/src/middleware/auth.ts
+++ b/services/nexus-web-service/src/middleware/auth.ts
@@ -1,0 +1,31 @@
+// src/middleware/auth.ts
+import { Request } from 'express';
+import jwt from 'jsonwebtoken';
+import { ACCESS_JWT_SECRET } from '../config';
+import { UnauthenticatedError, getAccessToken } from '../utils';
+
+// URL paths & operation names you want to skip (login/refresh, introspection, etc)
+const OPEN_OPERATIONS = new Set([
+    'IntrospectionQuery',
+    'LoginUser',
+    'RegisterUser',
+    'RefreshToken',
+]);
+
+export type AuthGuardOptions = {
+    operationName?: string;
+    req: Request;
+};
+
+export function authGuard({ operationName, req }: AuthGuardOptions): void {
+    if (operationName && OPEN_OPERATIONS.has(operationName)) return;
+
+    const token = getAccessToken(req);
+    if (!token) throw new UnauthenticatedError('Not authenticated');
+
+    try {
+        jwt.verify(token, ACCESS_JWT_SECRET as jwt.Secret);
+    } catch {
+        throw new UnauthenticatedError('Invalid or expired token');
+    }
+}

--- a/services/nexus-web-service/src/middleware/index.ts
+++ b/services/nexus-web-service/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './auth';

--- a/services/nexus-web-service/src/schemaTypeDefs/index.ts
+++ b/services/nexus-web-service/src/schemaTypeDefs/index.ts
@@ -10,7 +10,7 @@ type Mutation {
   loginUser(
     email: String!
     password: String!
-  ): User
+  ): LoginResponse
 
   refreshToken(refreshToken: String): RefreshTokenResponse
 
@@ -22,7 +22,7 @@ type Mutation {
     lastName: String!
     phoneNumber: String!
     status: UserOnlineStatus
-  ): User
+  ): LoginResponse
 
   updateUser(
     id: String!
@@ -164,6 +164,7 @@ enum UserOnlineStatus {
 type RefreshTokenResponse {
   accessToken: String!
   refreshToken: String!
+  refreshTokenExpiresAt: String!
 }
 
 type User {
@@ -174,9 +175,20 @@ type User {
   lastName: String!
   phoneNumber: String!
   status: UserOnlineStatus!
+}
+
+type LoginResponse {
+  id: String!
+  email: String!
+  username: String!
+  firstName: String!
+  lastName: String!
+  phoneNumber: String!
+  status: UserOnlineStatus!
   token: String
   accessToken: String!
   refreshToken: String!
+  refreshTokenExpiresAt: String!
 }
 
 ###########################

--- a/services/nexus-web-service/src/schemaTypeDefs/index.ts
+++ b/services/nexus-web-service/src/schemaTypeDefs/index.ts
@@ -5,7 +5,6 @@ export const schemaTypeDefs = `#graphql
 ###########################
 scalar Upload
 
-
 type Mutation {
   loginUser(
     email: String!
@@ -142,7 +141,6 @@ type Query {
   getConversations(userId: String!): [Conversation!]!
   getConversationMessages(conversationId: String!, offset: Int!, limit: Int!): [Message!]!
 }
-
 
 type Subscription {
   messageAdded(channelId: String!): GroupChannelMessage!

--- a/services/nexus-web-service/src/schemaTypeDefs/index.ts
+++ b/services/nexus-web-service/src/schemaTypeDefs/index.ts
@@ -12,6 +12,8 @@ type Mutation {
     password: String!
   ): User
 
+  refreshToken(refreshToken: String): RefreshTokenResponse
+
   registerUser(
     email: String!
     username: String!
@@ -159,6 +161,11 @@ enum UserOnlineStatus {
   invisible
 }
 
+type RefreshTokenResponse {
+  accessToken: String!
+  refreshToken: String!
+}
+
 type User {
   id: String!
   email: String!
@@ -168,6 +175,8 @@ type User {
   phoneNumber: String!
   status: UserOnlineStatus!
   token: String
+  accessToken: String!
+  refreshToken: String!
 }
 
 ###########################

--- a/services/nexus-web-service/src/utils/UnauthenticatedError.ts
+++ b/services/nexus-web-service/src/utils/UnauthenticatedError.ts
@@ -1,0 +1,12 @@
+import { GraphQLError } from 'graphql';
+
+export class UnauthenticatedError extends GraphQLError {
+    constructor(message: string) {
+        super(message, {
+            extensions: {
+                code: 'UNAUTHENTICATED',
+                http: { status: 401 },
+            },
+        });
+    }
+}

--- a/services/nexus-web-service/src/utils/getAccessToken.ts
+++ b/services/nexus-web-service/src/utils/getAccessToken.ts
@@ -1,0 +1,19 @@
+import { Request } from 'express';
+import { IncomingMessage } from 'node:http';
+import * as cookie from 'cookie';
+
+export function getAccessToken(req: Request | IncomingMessage) {
+    const raw = req.headers.cookie ?? '';
+    const { access_token: cookieToken } = cookie.parse(raw);
+
+    // 2. try Authorization header
+    const authHeader = req.headers.authorization;
+    const headerToken =
+        authHeader && authHeader.startsWith('Bearer ')
+            ? authHeader.slice(7)
+            : undefined;
+
+    const token = cookieToken ?? headerToken;
+
+    return token;
+}

--- a/services/nexus-web-service/src/utils/index.ts
+++ b/services/nexus-web-service/src/utils/index.ts
@@ -2,4 +2,6 @@ export * from './fetchAttachmentsForComment';
 export * from './fetchAttachmentsForCommentsRecursive';
 export * from './fetchAttachmentsForDm';
 export * from './fetchAttachmentsForMessage';
+export * from './getAccessToken';
 export * from './getCachedSignedUrl';
+export * from './UnauthenticatedError';

--- a/services/user-api/package.json
+++ b/services/user-api/package.json
@@ -20,6 +20,7 @@
   "keywords": [],
   "author": "Mars Lyceum Inc.",
   "dependencies": {
+    "friends-api-client": "workspace:*",
     "third-party-clients": "workspace:*",
     "@google-cloud/trace-agent": "^8.0.0",
     "@google-cloud/api-gateway": "^3.3.0",

--- a/services/user-api/pnpm-lock.yaml
+++ b/services/user-api/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       express-serve-static-core:
         specifier: ^0.1.1
         version: 0.1.1
+      friends-api-client:
+        specifier: workspace:*
+        version: link:../../packages/friends-api-client
       group-api-client:
         specifier: workspace:*
         version: link:../../packages/group-api-client

--- a/services/user-api/src/handlers/updateUser.ts
+++ b/services/user-api/src/handlers/updateUser.ts
@@ -40,11 +40,6 @@ export const updateUser = async (
                 const topicName = `u-${friend.user.id}`;
                 const topic = pubsub.topic(topicName);
 
-                const [exists] = await topic.exists();
-                if (!exists) {
-                    await pubsub.createTopic(topicName);
-                }
-
                 await topic.publishMessage({ data: dataBuffer });
             }
         }

--- a/services/user-api/src/handlers/updateUser.ts
+++ b/services/user-api/src/handlers/updateUser.ts
@@ -64,7 +64,7 @@ export const updateUser = async (
 
         await dataSource.manager.save(user);
 
-        res.status(204).json(user);
+        res.status(200).json(user);
     } catch (error) {
         res.status(500).send((error as Error).message);
     }


### PR DESCRIPTION
Make websocket subscriptions and Google Pub/Sub topics more efficient and scalable by broadcasting events for each user rather than per event. This means that we use the user's access token to grab their user id and make that a Google Pub/Sub topic then when we broadcast events we broadcast for each user in the group or message, etc. Rather than just broadcasting a very generic event to everyone and filtering it. This increases security as it means that users will only get events that belong to them. It also means that we will be able to scale better because we won't be bombarding the nexus-web-service for each user with every event from all users and instead will be only broadcasting small numbers of events for the relevant users.

As part of this change I also added enforcement of valid access tokens and added refresh tokens so now we have a refresh token route which will renew both tokens. I also put most of the routes behind an access token check so users will have to be logged in with a valid access token to use the app. This will need to be changed later to support public groups so users can use the app without being logged in but this is needed for private groups, dms, and everything that requires you to be logged in.